### PR TITLE
Drop support for MRI 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0


### PR DESCRIPTION
Wondering if we should leave a comment in the README for this or just let it slip. What do you guys think?
