### PR TITLE
Fix #7 Exclude users or words

### DIFF
--- a/app/models/mingle/instagram.rb
+++ b/app/models/mingle/instagram.rb
@@ -43,6 +43,28 @@ module Mingle::Instagram
   #
   # Returns a Boolean.
   def self.ignore? photo
-    Mingle.config.since && photo.created_at < Mingle.config.since
+    include_rejected_word?(photo.message) || 
+      rejected_user?(photo.user_handle) ||
+      created_before?(photo, Mingle.config.since)
+  end
+
+  # TODO: Refactor to Photo
+  def self.created_before?(photo, date)
+    return false unless date
+
+    photo.created_at < Mingle.config.since
+  end
+
+  # TODO: Refactor to Photo
+  def self.include_rejected_word?(message)
+    return false unless message
+
+    message.split(' ').inject(true) do |bool, word|
+      bool && Mingle.config.instagram_reject_words.include?(word.downcase)
+    end
+  end
+
+  def self.rejected_user?(user)
+    Mingle.config.instagram_reject_users.include? user
   end
 end

--- a/app/models/mingle/instagram.rb
+++ b/app/models/mingle/instagram.rb
@@ -43,28 +43,9 @@ module Mingle::Instagram
   #
   # Returns a Boolean.
   def self.ignore? photo
-    include_rejected_word?(photo.message) || 
-      rejected_user?(photo.user_handle) ||
-      created_before?(photo, Mingle.config.since)
+    photo.include_rejected_word?(Mingle.config.instagram_reject_words) || 
+      photo.rejected_user?(Mingle.config.instagram_reject_users) ||
+      photo.created_before?(Mingle.config.since)
   end
 
-  # TODO: Refactor to Photo
-  def self.created_before?(photo, date)
-    return false unless date
-
-    photo.created_at < Mingle.config.since
-  end
-
-  # TODO: Refactor to Photo
-  def self.include_rejected_word?(message)
-    return false unless message
-
-    message.split(' ').inject(true) do |bool, word|
-      bool && Mingle.config.instagram_reject_words.include?(word.downcase)
-    end
-  end
-
-  def self.rejected_user?(user)
-    Mingle.config.instagram_reject_users.include? user
-  end
 end

--- a/app/models/mingle/twitter.rb
+++ b/app/models/mingle/twitter.rb
@@ -13,7 +13,7 @@ module Mingle::Twitter
       options[:exclude] = 'retweets' if Mingle.config.twitter_ignore_retweets
 
       hashtags.map do |hashtag|
-        client.search(hashtag.tag_name_with_hash, options).collect do |data|
+        client.search(query_string(hashtag), options).collect do |data|
           tweet = Tweet.find_or_initialize_by tweet_id: data.id.to_s
 
           tweet.attributes = {
@@ -55,6 +55,29 @@ module Mingle::Twitter
     # Returns a Boolean.
     def ignore? tweet
       Mingle.config.since && tweet.created_at < Mingle.config.since
+    end
+
+    # Builds query string for Tweet search.
+    #
+    # Returns a String.
+    def query_string(hashtag)
+      hashtag.tag_name_with_hash +
+        rejected_words_string +
+        rejected_users_string
+    end
+
+    # Builds rejected words query string for Tweet search.
+    #
+    # Returns a String.
+    def rejected_words_string
+      Mingle.config.twitter_reject_words.map {|w| " -#{w}"}.join
+    end
+
+    # Builds rejected users query string for Tweet search.
+    #
+    # Returns a String.
+    def rejected_users_string
+      Mingle.config.twitter_reject_users.map {|w| " -from:#{w}"}.join
     end
   end
 

--- a/app/models/mingle/twitter.rb
+++ b/app/models/mingle/twitter.rb
@@ -54,7 +54,7 @@ module Mingle::Twitter
     #
     # Returns a Boolean.
     def ignore? tweet
-      Mingle.config.since && tweet.created_at < Mingle.config.since
+      tweet.created_before?(Mingle.config.since)
     end
 
     # Builds query string for Tweet search.

--- a/lib/mingle/concerns/models/instagram/photo.rb
+++ b/lib/mingle/concerns/models/instagram/photo.rb
@@ -16,5 +16,23 @@ module Mingle::Concerns::Models::Instagram::Photo
     def avatar
       user_image_url
     end
+
+    def created_before?(date)
+      return false unless date
+
+      created_at < date
+    end
+
+    def rejected_user?(rejected_users)
+      rejected_users.include? user_handle
+    end
+
+    def include_rejected_word?(rejected_words)
+      return false if !message || message.empty?
+
+      message.split(' ').inject(true) do |bool, word|
+        bool && rejected_words.include?(word.downcase)
+      end
+    end
   end
 end

--- a/lib/mingle/concerns/models/twitter/tweet.rb
+++ b/lib/mingle/concerns/models/twitter/tweet.rb
@@ -22,5 +22,11 @@ module Mingle::Concerns::Models::Twitter::Tweet
     def url
       "https://twitter.com/#{user_handle}/status/#{tweet_id}"
     end
+
+    def created_before?(date)
+      return false unless date
+
+      created_at < date
+    end
   end
 end

--- a/lib/mingle/configuration.rb
+++ b/lib/mingle/configuration.rb
@@ -3,13 +3,16 @@ module Mingle
     configs = [
       :facebook_access_token, :twitter_api_key, :twitter_api_secret,
       :twitter_access_token, :twitter_access_token_secret,
-      :twitter_ignore_retweets, :instagram_client_id, :since
+      :twitter_ignore_retweets, :instagram_client_id, :since,
+      :twitter_reject_words, :twitter_reject_users
     ]
 
     attr_accessor *configs
 
     def initialize
       @twitter_ignore_retweets = false
+      @twitter_reject_words = []
+      @twitter_reject_users = []
     end
 
     def facebook_access_token

--- a/lib/mingle/configuration.rb
+++ b/lib/mingle/configuration.rb
@@ -4,15 +4,18 @@ module Mingle
       :facebook_access_token, :twitter_api_key, :twitter_api_secret,
       :twitter_access_token, :twitter_access_token_secret,
       :twitter_ignore_retweets, :instagram_client_id, :since,
-      :twitter_reject_words, :twitter_reject_users
+      :twitter_reject_words, :twitter_reject_users,
+      :instagram_reject_words, :instagram_reject_users
     ]
 
     attr_accessor *configs
 
     def initialize
       @twitter_ignore_retweets = false
-      @twitter_reject_words = []
-      @twitter_reject_users = []
+      @twitter_reject_words    = []
+      @twitter_reject_users    = []
+      @instagram_reject_words  = []
+      @instagram_reject_users  = []
     end
 
     def facebook_access_token

--- a/spec/lib/mingle/configuration_spec.rb
+++ b/spec/lib/mingle/configuration_spec.rb
@@ -72,4 +72,16 @@ describe Mingle::Configuration do
       expect(subject.twitter_reject_users).to eq([])
     end
   end
+
+  describe "instagram_ignore_words" do
+    it 'defaults to empty array' do
+      expect(subject.instagram_reject_words).to eq([])
+    end
+  end
+
+  describe "instagram_ignore_users" do
+    it 'defaults to empty array' do
+      expect(subject.instagram_reject_users).to eq([])
+    end
+  end
 end

--- a/spec/lib/mingle/configuration_spec.rb
+++ b/spec/lib/mingle/configuration_spec.rb
@@ -60,4 +60,16 @@ describe Mingle::Configuration do
       expect(subject.twitter_ignore_retweets).not_to be # it's not
     end
   end
+
+  describe "twitter_ignore_words" do
+    it 'defaults to empty array' do
+      expect(subject.twitter_reject_words).to eq([])
+    end
+  end
+
+  describe "twitter_ignore_users" do
+    it 'defaults to empty array' do
+      expect(subject.twitter_reject_users).to eq([])
+    end
+  end
 end

--- a/spec/models/mingle/instagram/photo_spec.rb
+++ b/spec/models/mingle/instagram/photo_spec.rb
@@ -12,4 +12,50 @@ describe Mingle::Instagram::Photo do
       expect(subject.avatar).to eq subject.user_image_url
     end
   end
+
+  describe "#created_before?" do
+    it 'should return true' do
+      photo = described_class.new(created_at: 1.day.ago)
+      expect(photo.created_before?(Date.current)).to eq(true)
+    end
+
+    it 'should return false' do
+      photo = described_class.new(created_at: 1.day.ago)
+      expect(photo.created_before?(2.day.ago)).to eq(false)
+    end
+
+    it 'should return false when date is nil' do
+      photo = described_class.new(created_at: 1.day.ago)
+      expect(photo.created_before?(nil)).to eq(false)
+    end
+  end
+
+  describe "#rejected_user?" do
+    it "should return true" do
+      photo = described_class.new(user_handle: 'rejected_user')
+      expect(photo.rejected_user?(['rejected_user'])).to eq(true)
+    end
+    it "should return false" do
+      photo = described_class.new(user_handle: 'not_rejected_user')
+      expect(photo.rejected_user?(['rejected_user'])).to eq(false)
+    end
+  end
+
+  describe '#include_rejected_word?' do
+    it "should return true" do
+      photo = described_class.new(message: 'rejectedWord')
+      expect(photo.include_rejected_word?(['rejectedword'])).to eq(true)
+    end
+
+    it 'should return false when message is nil' do
+      photo = described_class.new(message: nil)
+      expect(photo.include_rejected_word?(['rejectedword'])).to eq(false)
+    end
+
+    it "should return false" do
+      photo = described_class.new(message: 'notRejectedWord')
+      expect(photo.include_rejected_word?(['rejectedword'])).to eq(false)
+    end
+
+  end
 end

--- a/spec/models/mingle/instagram_spec.rb
+++ b/spec/models/mingle/instagram_spec.rb
@@ -57,34 +57,28 @@ describe Mingle::Instagram do
     expect(photo.hashtags).to eq [ hashtag ]
   end
 
-  it 'will ignore photos that are too old' do
+  it 'will ignore photos that should be ignored' do
     stub_request(:get, /api\.instagram\.com\/v1\/tags\/klhd\/media\/recent\.json/).to_return body: fixture('mingle/instagram/photos.json')
+    allow(described_class).to receive(:ignore?).and_return(true)
 
-    Mingle.temporarily since: Time.now do
-      photos = Mingle::Instagram.fetch hashtag
+    photos = Mingle::Instagram.fetch hashtag
 
-      expect(photos.count).to eq 0
+    expect(photos.count).to eq 0
+  end
+
+
+  describe "#ignore?" do
+    it 'should return true' do
+      photo = double('a photo', include_rejected_word?: false, rejected_user?: true, created_before?: true)
+
+      expect(described_class.ignore? photo).to eq(true)
+    end
+
+    it 'should return false' do
+      photo = double('a photo', include_rejected_word?: false, rejected_user?: false, created_before?: false)
+
+      expect(described_class.ignore? photo).to eq(false)
     end
   end
 
-  it 'will ignore photos with rejected words' do
-    stub_request(:get, /api\.instagram\.com\/v1\/tags\/klhd\/media\/recent\.json/).to_return body: fixture('mingle/instagram/photos.json')
-
-    Mingle.temporarily instagram_reject_words: ['foo'] do
-      photos = Mingle::Instagram.fetch hashtag
-
-      expect(photos.count).to eq 1
-    end
-
-  end
-  it 'will ignore photos from rejected user' do
-    stub_request(:get, /api\.instagram\.com\/v1\/tags\/klhd\/media\/recent\.json/).to_return body: fixture('mingle/instagram/photos.json')
-
-    Mingle.temporarily instagram_reject_users: ['eivindhilling']do
-      photos = Mingle::Instagram.fetch hashtag
-
-      expect(photos.count).to eq 0
-    end
-
-  end
 end

--- a/spec/models/mingle/instagram_spec.rb
+++ b/spec/models/mingle/instagram_spec.rb
@@ -66,4 +66,25 @@ describe Mingle::Instagram do
       expect(photos.count).to eq 0
     end
   end
+
+  it 'will ignore photos with rejected words' do
+    stub_request(:get, /api\.instagram\.com\/v1\/tags\/klhd\/media\/recent\.json/).to_return body: fixture('mingle/instagram/photos.json')
+
+    Mingle.temporarily instagram_reject_words: ['foo'] do
+      photos = Mingle::Instagram.fetch hashtag
+
+      expect(photos.count).to eq 1
+    end
+
+  end
+  it 'will ignore photos from rejected user' do
+    stub_request(:get, /api\.instagram\.com\/v1\/tags\/klhd\/media\/recent\.json/).to_return body: fixture('mingle/instagram/photos.json')
+
+    Mingle.temporarily instagram_reject_users: ['eivindhilling']do
+      photos = Mingle::Instagram.fetch hashtag
+
+      expect(photos.count).to eq 0
+    end
+
+  end
 end

--- a/spec/models/mingle/twitter/tweet_spec.rb
+++ b/spec/models/mingle/twitter/tweet_spec.rb
@@ -20,4 +20,21 @@ describe Mingle::Twitter::Tweet do
       expect(subject.url).to eq "https://twitter.com/sindre/status/1337"
     end
   end
+
+  describe "#created_before?" do
+    it 'should return true' do
+      photo = described_class.new(created_at: 1.day.ago)
+      expect(photo.created_before?(Date.current)).to eq(true)
+    end
+
+    it 'should return false' do
+      photo = described_class.new(created_at: 1.day.ago)
+      expect(photo.created_before?(2.day.ago)).to eq(false)
+    end
+
+    it 'should return false when date is nil' do
+      photo = described_class.new(created_at: 1.day.ago)
+      expect(photo.created_before?(nil)).to eq(false)
+    end
+  end
 end

--- a/spec/models/mingle/twitter/tweet_spec.rb
+++ b/spec/models/mingle/twitter/tweet_spec.rb
@@ -23,18 +23,18 @@ describe Mingle::Twitter::Tweet do
 
   describe "#created_before?" do
     it 'should return true' do
-      photo = described_class.new(created_at: 1.day.ago)
-      expect(photo.created_before?(Date.current)).to eq(true)
+      tweet = described_class.new(created_at: 1.day.ago)
+      expect(tweet.created_before?(Date.current)).to eq(true)
     end
 
     it 'should return false' do
-      photo = described_class.new(created_at: 1.day.ago)
-      expect(photo.created_before?(2.day.ago)).to eq(false)
+      tweet = described_class.new(created_at: 1.day.ago)
+      expect(tweet.created_before?(2.day.ago)).to eq(false)
     end
 
     it 'should return false when date is nil' do
-      photo = described_class.new(created_at: 1.day.ago)
-      expect(photo.created_before?(nil)).to eq(false)
+      tweet = described_class.new(created_at: 1.day.ago)
+      expect(tweet.created_before?(nil)).to eq(false)
     end
   end
 end

--- a/spec/models/mingle/twitter_spec.rb
+++ b/spec/models/mingle/twitter_spec.rb
@@ -12,6 +12,8 @@ describe Mingle::Twitter do
       config.twitter_access_token = '...'
       config.twitter_access_token_secret = '...'
       config.twitter_ignore_retweets = false
+      config.twitter_reject_words = []
+      config.twitter_reject_users = []
     end
   end
 
@@ -36,6 +38,22 @@ describe Mingle::Twitter do
   it 'can fetch tweets and ignore retweets' do
     Mingle.config.twitter_ignore_retweets = true
     Twitter::REST::Client.any_instance.should_receive(:search).with("#klhd", exclude: 'retweets', since_id: nil)
+      .and_return double(collect: [])
+
+    Mingle::Twitter.fetch hashtag
+  end
+
+  it 'can fetch tweets and exclude words' do
+    Mingle.config.twitter_reject_words = ['boobs']
+    Twitter::REST::Client.any_instance.should_receive(:search).with("#klhd -boobs", since_id: nil)
+      .and_return double(collect: [])
+
+    Mingle::Twitter.fetch hashtag
+  end
+
+  it 'can fetch tweets and exclude users' do
+    Mingle.config.twitter_reject_users = ['rejectedUser']
+    Twitter::REST::Client.any_instance.should_receive(:search).with("#klhd -from:rejectedUser", since_id: nil)
       .and_return double(collect: [])
 
     Mingle::Twitter.fetch hashtag


### PR DESCRIPTION
Add possibility to exclude words or user on Instagram and Twitter fetch through adding words/user to Mingle::Configuration.

With this configuration:
``` ruby
Mingle.config do |config|
  config.twitter_reject_words = ['boobs']
  config.twitter_reject_users = ['rejecteduser']
  config.instagram_reject_words = ['boobs']
  config.instagram_reject_users = ['rejecteduser']
end
```
Tweets and photos with user 'rejecteduser' and/or message 'boobs' is not imported. 

