### PR TITLE
Clean up instagram removed items

### DIFF
--- a/app/models/mingle/instagram.rb
+++ b/app/models/mingle/instagram.rb
@@ -11,4 +11,15 @@ module Mingle::Instagram
       PhotosFetcher.new(hashtag).fetch
     end
   end
+
+  def self.prune
+    Mingle::Instagram::Photo.all.each{|photo|
+      uri = URI(photo.url)
+      Net::HTTP.start(uri.host, uri.port,
+        :use_ssl => uri.scheme == 'https') do |http|
+        res = http.request(Net::HTTP::Head.new(uri))
+        photo.destroy if res.code != '200'
+      end
+    }
+  end
 end

--- a/app/models/mingle/instagram/photos_fetcher.rb
+++ b/app/models/mingle/instagram/photos_fetcher.rb
@@ -4,32 +4,18 @@ module Mingle::Instagram
   class PhotosFetcher
     def initialize(hashtag)
       @hashtag = hashtag
-      @recent_proccesed_media = []
       Instagram.configure do |config|
         config.client_id = Mingle.config.instagram_client_id
       end
     end
 
     def fetch
-      result = valid_photos.each {|p| p.save!}
-      verifying_integrity_for_deleted_photos
-      result
+      valid_photos.each {|p| p.save!}
     end
 
     private
 
     attr_reader :hashtag
-
-    def verifying_integrity_for_deleted_photos
-      Photo.where.not(photo_id: @recent_proccesed_media).each{|photo|
-        uri = URI(photo.url)
-        Net::HTTP.start(uri.host, uri.port,
-          :use_ssl => uri.scheme == 'https') do |http|
-          res = http.request(Net::HTTP::Head.new(uri))
-          photo.destroy if res.code != '200'
-        end
-      }
-    end
 
     def valid_photos
       photos_for_hashtag.reject {|p| ignore? p }
@@ -43,7 +29,6 @@ module Mingle::Instagram
 
     def photos_for_hashtag
       imagedata_for_hashtag.map  do |media| 
-        @recent_proccesed_media << media.id
         Photo.find_or_initialize_by(photo_id: media.id).tap do |photo|
           photo.attributes = {
             created_at: Time.at(media.created_time.to_i),

--- a/app/models/mingle/instagram/photos_fetcher.rb
+++ b/app/models/mingle/instagram/photos_fetcher.rb
@@ -11,8 +11,9 @@ module Mingle::Instagram
     end
 
     def fetch
-      valid_photos.each {|p| p.save!}
+      result = valid_photos.each {|p| p.save!}
       verifying_integrity_for_deleted_photos
+      result
     end
 
     private

--- a/lib/tasks/mingle_tasks.rake
+++ b/lib/tasks/mingle_tasks.rake
@@ -44,6 +44,11 @@ namespace :mingle do
       Mingle::Instagram::Photo.destroy_all
     end
 
+    desc "Clean up Instagram removed photos"
+    task prune: :environment do
+      Mingle::Instagram.prune
+    end
+
   end
 
 end


### PR DESCRIPTION
Clean up instagram removed items consists in verifying deleted photos doing a http (head) request for stored photos, You have to check this after fetching photos. I try to do the process more efficient ignoring recently fetched photos.
